### PR TITLE
Fixes #4: Caps Lock OFF not detected on a Mac (Chrome & Safari & Opera)

### DIFF
--- a/src/jquery.capslockstate.js
+++ b/src/jquery.capslockstate.js
@@ -93,6 +93,17 @@
 				helpers.hasStateChange(previousState, capsLockState);
 			});
 
+			// On MacIntel Chrome and Safari when the Caps Lock is deactivated
+			// it fires only a keyup event and no keydown event.
+			if (/MacIntel/.test(window.navigator.platform)) {
+				// Check if key was Caps Lock key
+				$('body').bind("keyup.capslockstate", function (event) {
+					var previousState = capsLockState;
+					capsLockState = helpers.isCapslockKey(event);
+					helpers.hasStateChange(previousState, capsLockState);
+				});
+			}
+
 			// If the window loses focus then we no longer know the state
 			$(window).bind("focus.capslockstate", function() {
 				var previousState = capsLockState;

--- a/src/jquery.capslockstate.js
+++ b/src/jquery.capslockstate.js
@@ -93,8 +93,8 @@
 				helpers.hasStateChange(previousState, capsLockState);
 			});
 
-			// On MacIntel Chrome and Safari when the Caps Lock is deactivated
-			// it fires only a keyup event and no keydown event.
+			// On MacIntel Chrome, Safari and Opera when the Caps Lock is
+			// deactivated it fires only a keyup event and no keydown event.
 			if (/MacIntel/.test(window.navigator.platform)) {
 				// Check if key was Caps Lock key
 				$('body').bind("keyup.capslockstate", function (event) {


### PR DESCRIPTION
* When Caps Lock is turned OFF on a Mac (Chrome & Safari & Opera), only a keyup
event is fired. No keydown event is fired in that case, so we bind a
listener on keyup to detect when Caps Lock is turned OFF.
* Only fixed for MacIntel, could not test on MacPPC
* Mac FF is not affected as it only fires keydown events
* See [Demo](http://jsfiddle.net/tBB58/157/)